### PR TITLE
Use node group prefix instead of name eks.ts

### DIFF
--- a/aws/eks/eks.ts
+++ b/aws/eks/eks.ts
@@ -57,7 +57,7 @@ export const cluster = new eks.Cluster(`${eksClusterName}-cluster`, {
 //   labels: {
 //     ondemand: "true", // Label the node group as on-demand nodes
 //   },
-//   nodeGroupName: `${eksClusterName}-nodegroup`, // Name of the node group
+//   nodeGroupNamePrefix: `${eksClusterName}-nodegroup-`, // Prefix name of the node group
 //   nodeRoleArn: cluster.instanceRoles[0].arn, // Use the first instance role created earlier
 //   scalingConfig: {
 //     desiredSize: desiredSize, // Desired number of worker nodes


### PR DESCRIPTION
Using node group name causes an error if you update the node group variables. For example instance type. Using node name prefix instead of the same name allows pulumi to do proper replace.